### PR TITLE
replace APPDATA with LOCALAPPDATA

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,11 +52,11 @@ func main() {
 	} else if *gpgFile != "" {
 		fileName := *gpgFile
 		if !filepath.IsAbs(fileName) {
-			appdata, ok := os.LookupEnv("APPDATA")
+			localAppData, ok := os.LookupEnv("LOCALAPPDATA")
 			if !ok {
-				log.Fatal("Missing the %APPDATA% variable?")
+				log.Fatal("Missing the %LOCALAPPDATA% variable?")
 			}
-			gpgDir := filepath.Join(appdata, "gnupg")
+			gpgDir := filepath.Join(localAppData, "gnupg")
 			_, err := os.Stat(gpgDir)
 			if os.IsNotExist(err) {
 				log.Fatalf("The directory %q doesn't exist, please specify your full GPG path", gpgDir)


### PR DESCRIPTION
Somewhere in GnuPG version 2.3.x, the location of the sockets on windows
changed from %APPDATA%/gnupg to %LOCALAPPDATA%/gnupg. This commit fixes
the paths where wsl-relay searches for the gpg-agent sockets.